### PR TITLE
Fix error Class URLsProperty not found

### DIFF
--- a/src/Plugin/search_api/processor/Urls.php
+++ b/src/Plugin/search_api/processor/Urls.php
@@ -6,7 +6,7 @@ use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Item\ItemInterface;
 use Drupal\search_api\Processor\ProcessorPluginBase;
 use Drupal\search_api\Processor\ProcessorProperty;
-use Drupal\search_api_field_map\Plugin\search_api\processor\Property\URLsProperty;
+use Drupal\search_api_field_map\Plugin\search_api\processor\Property\UrlsProperty;
 
 
 /**
@@ -38,7 +38,7 @@ class Urls extends ProcessorPluginBase {
         'type' => 'string',
         'processor_id' => $this->getPluginId(),
       ];
-      $properties['search_api_urls'] = new URLsProperty($definition);
+      $properties['search_api_urls'] = new UrlsProperty($definition);
     }
 
     return $properties;


### PR DESCRIPTION
I encountered the following error after enabling the module:
Fatal error: Uncaught Error: Class 'Drupal\search_api_field_map\Plugin\search_api\processor\Property\URLsProperty' not found in /var/www/drupal8/web/modules/contrib/search_api_field_map/src/Plugin/search_api/processor/Urls.php on line 41

Error: Class 'Drupal\search_api_field_map\Plugin\search_api\processor\Property\URLsProperty' not found in /var/www/drupal8/web/modules/contrib/search_api_field_map/src/Plugin/search_api/processor/Urls.php on line 41

It looks like it's a problem of lowercase vs uppercase.