### PR TITLE
Root-198: avoid adding blank terms

### DIFF
--- a/src/Plugin/search_api/processor/MappedTerms.php
+++ b/src/Plugin/search_api/processor/MappedTerms.php
@@ -118,7 +118,10 @@ class MappedTerms extends ProcessorPluginBase {
             // If the mapped_terms field is populated, add its values to the destination_terms array.
             if (!empty($mapped_term_values)) {
               foreach ($mapped_term_values as $mapped_term_value) {
-                $mapped_terms_destination_values[] = $mapped_term_value['value'];
+                // Avoid adding empty strings as values.
+                if (strlen(trim($mapped_term_value['value']))) {
+                  $mapped_terms_destination_values[] = $mapped_term_value['value'];
+                }
               };
             }
           }


### PR DESCRIPTION
This PR updates the logic in the terms processor to ensure that empty strings are not added as terms.

Test as part of https://github.com/palantirnet/search_api_federated_solr/compare/features/d8/root-198-autocomplete-config