### PR TITLE
3044934: enable use of site name token for site name property

### DIFF
--- a/config/schema/search_api_federated_solr.processor.schema.yml
+++ b/config/schema/search_api_federated_solr.processor.schema.yml
@@ -16,6 +16,9 @@ search_api.property_configuration.site_name:
   type: mapping
   label: 'Site name processor configuration'
   mapping:
+    use_system_site_name:
+      type: integer
+      label: 'Flag indicating use of the value for the system site name token'
     site_name:
       type: string
-      label: 'The name of the site'
+      label: 'Custom name for the site'

--- a/search_api_field_map.install
+++ b/search_api_field_map.install
@@ -7,7 +7,8 @@
 
 
 /**
- * Disable use of the system site name token for site name property config.
+ * For Federated Search App selected index config, disable use of the system site name
+ * token for site name property by default.
  */
 function search_api_field_map_update_8101(&$sandbox) {
   $config_factory = \Drupal::configFactory();

--- a/search_api_field_map.install
+++ b/search_api_field_map.install
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Contains install and update hooks for the Search API Field Map Module.
+ */
+
+
+/**
+ * Disable use of the system site name token for site name property config.
+ */
+function search_api_field_map_update_8101(&$sandbox) {
+  $config_factory = \Drupal::configFactory();
+  // Get the federated search app config.
+  if ($app_config = $config_factory->get('search_api_federated_solr.search_app.settings')) {
+    // Determine the id of the selected index.
+    $index_id = $app_config->get('index.id');
+    // Load mutable index config object.
+    // This will create a configuration object if it doesn't already exist.
+    $index_config = $config_factory->getEditable('search_api.index.' . $index_id);
+    $index_field_settings = $index_config->get('field_settings');
+    // If there are added fields and site_name is one of those added fields.
+    if (is_array($index_field_settings) && array_key_exists('site_name', $index_field_settings)) {
+      // Disable the flag by default.
+      $index_config->set('field_settings.site_name.configuration.use_system_site_name', 0);
+      $index_config->save(TRUE);
+    }
+  }
+}

--- a/src/Plugin/search_api/processor/Property/SiteNameProperty.php
+++ b/src/Plugin/search_api/processor/Property/SiteNameProperty.php
@@ -55,7 +55,7 @@ class SiteNameProperty extends ConfigurablePropertyBase {
     $form['site_name_group']['use_system_site_name'] = [
       '#type' => 'checkbox',
       '#title' => '<b>' . $this->t('Use the site name from '. $basic_site_settings_page_link  .' > Site Details > Site Name') . '</b>',
-      '#default_value' => $configuration['use_system_site_name'],
+      '#default_value' => isset($configuration['use_system_site_name']) ? $configuration['use_system_site_name'] : 0,
       '#description' => $this->t('This option is recommended for multisite installations that share config across sites.'),
       '#attributes' => [
         'data-use-system-site-name' => TRUE,
@@ -66,7 +66,7 @@ class SiteNameProperty extends ConfigurablePropertyBase {
       '#type' => 'textfield',
       '#title' => $this->t('Site Name'),
       '#description' => $this->t('Create a Site Name.'),
-      '#default_value' => $configuration['site_name'],
+      '#default_value' => isset($configuration['site_name']) ? $configuration['site_name'] : '',
       '#states' => [
         'visible' => [
           ':input[data-use-system-site-name]' => [

--- a/src/Plugin/search_api/processor/Property/SiteNameProperty.php
+++ b/src/Plugin/search_api/processor/Property/SiteNameProperty.php
@@ -4,6 +4,8 @@ namespace Drupal\search_api_field_map\Plugin\search_api\processor\Property;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Drupal\search_api\Item\FieldInterface;
 use Drupal\search_api\Processor\ConfigurablePropertyBase;
 
@@ -31,15 +33,47 @@ class SiteNameProperty extends ConfigurablePropertyBase {
   public function buildConfigurationForm(FieldInterface $field, array $form, FormStateInterface $form_state) {
     $configuration = $field->getConfiguration();
 
+    // Create a link to the Basic Site Settings Page from route.
+    $options = [
+      'attributes' => [
+        'target' => '_blank'
+      ],
+    ];
+    $basic_site_settings_page_url = Url::fromRoute('system.site_information_settings', [], $options);
+    $basic_site_settings_page_link = Link::fromTextAndUrl('Basic Site settings page', $basic_site_settings_page_url)->toString();
+
+
     $form['#attached']['library'][] = 'search_api/drupal.search_api.admin_css';
     $form['#tree'] = TRUE;
 
-    $form['site_name'] = [
-      '#type' => 'textfield',
+    $form['site_name_group'] = [
+      '#type' => 'fieldset',
       '#title' => $this->t('Site Name'),
       '#description' => $this->t('The name of the site from which this content originated. This can be useful if indexing multiple sites with a single search index.'),
+    ];
+
+    $form['site_name_group']['use_system_site_name'] = [
+      '#type' => 'checkbox',
+      '#title' => '<b>' . $this->t('Use the site name from '. $basic_site_settings_page_link  .' > Site Details > Site Name') . '</b>',
+      '#default_value' => $configuration['use_system_site_name'],
+      '#description' => $this->t('This option is recommended for multisite installations that share config across sites.'),
+      '#attributes' => [
+        'data-use-system-site-name' => TRUE,
+      ],
+    ];
+
+    $form['site_name_group']['site_name'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Site Name'),
+      '#description' => $this->t('Create a Site Name.'),
       '#default_value' => $configuration['site_name'],
-      '#required' => TRUE,
+      '#states' => [
+        'visible' => [
+          ':input[data-use-system-site-name]' => [
+            'checked' => FALSE,
+          ],
+        ],
+      ],
     ];
 
     return $form;
@@ -48,9 +82,20 @@ class SiteNameProperty extends ConfigurablePropertyBase {
   /**
    * {@inheritdoc}
    */
+  public function validateConfigurationForm(FieldInterface $field, array &$form, FormStateInterface $form_state) {
+    // Confirm that at least one field is populated.
+    if (!$form_state->getValue(['site_name_group', 'use_system_site_name']) && !strlen($form_state->getValue(['site_name_group', 'site_name']))) {
+      $form_state->setError($form['site_name_group'], $this->t('Please either select the option to use the system site name or enter a site name.'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function submitConfigurationForm(FieldInterface $field, array &$form, FormStateInterface $form_state) {
     $values = [
-      'site_name' => $form_state->getValue('site_name'),
+      'use_system_site_name' => $form_state->getValue(['site_name_group', 'use_system_site_name']),
+      'site_name' => $form_state->getValue(['site_name_group', 'site_name']),
     ];
     $field->setConfiguration($values);
   }

--- a/src/Plugin/search_api/processor/SiteName.php
+++ b/src/Plugin/search_api/processor/SiteName.php
@@ -50,8 +50,20 @@ class SiteName extends ProcessorPluginBase {
   public function addFieldValues(ItemInterface $item) {
     $fields = $this->getFieldsHelper()
       ->filterForPropertyPath($item->getFields(), NULL, 'site_name');
+
     foreach ($fields as $field) {
+      // Default to value of the site name text field.
       $site_name = $field->getConfiguration()['site_name'];
+      // Check if flag to use [site:name] is set.
+      $use_system_site_name = $field->getConfiguration()['use_system_site_name'];
+      if ($use_system_site_name) {
+        $token = \Drupal::token();
+        // If the token replacement produces a value, add to this item.
+        if ($value = $token->replace('[site:name]', [], ['clear' => true])) {
+          $site_name = $value;
+        }
+      }
+
       $field->addValue($site_name);
     }
   }


### PR DESCRIPTION
This PR adds the option to use the system site name as the site name property.  It also provides an update hook which sets this option to false by default.